### PR TITLE
:sparkles:feature: 헤더 컴포넌트 기능 구현(Issue #45 완료)

### DIFF
--- a/src/components/InputField.jsx
+++ b/src/components/InputField.jsx
@@ -21,7 +21,7 @@ export default function InputField({
 }) {
   return (
     <div className="mb-5">
-      <label htmlFor="userEmail">{label}</label>
+      <label htmlFor={id}>{label}</label>
       <div className="py-[10px] flex border-solid border-b-4 border-gray3 focus-within:border-point-blue items-center">
         <input
           className="text-[20px] focus:outline-none flex-grow"

--- a/src/components/ProfileDropdown.jsx
+++ b/src/components/ProfileDropdown.jsx
@@ -1,0 +1,23 @@
+import useUserStore from "@zustand/userStore";
+import { Link } from "react-router-dom";
+
+export default function ProfileDropdown() {
+  const { resetUser } = useUserStore();
+
+  const logout = () => {
+    resetUser();
+    alert("로그아웃 되었습니다.");
+  };
+
+  return (
+    <ul className="absolute -bottom-[92] right-0 border border-gray2 bg-white z-50 w-[110px] rounded-md">
+      <li className="p-[14px] w-full">
+        <Link to="/create">상품등록</Link>
+      </li>
+      <hr className="border border-gray2" />
+      <li className="p-[14px]" onClick={logout}>
+        로그아웃
+      </li>
+    </ul>
+  );
+}

--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -15,6 +15,10 @@ export default function Header() {
     setDropdownVisible(!dropdownVisible);
   };
 
+  const hideDropdown = () => {
+    setDropdownVisible(false);
+  };
+
   return (
     <header className="container mt-[60px] mb-[60px] flex items-center justify-between">
       <Link to="/">
@@ -33,7 +37,12 @@ export default function Header() {
         </Link>
 
         {user ? (
-          <button type="button" className="relative" onClick={showDropdown}>
+          <button
+            type="button"
+            className="relative"
+            onClick={showDropdown}
+            onBlur={hideDropdown}
+          >
             <img
               className="w-10 h-10 rounded-full border-2 border-gray1 box-content"
               src={`https://11.fesp.shop/${user?.profileImage}`} // 프로필 이미지가 없으면 기본 이미지 노출

--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -1,15 +1,19 @@
+import ProfileDropdown from "@components/ProfileDropdown";
 import useUserStore from "@zustand/userStore";
+import { useState } from "react";
 import { Link } from "react-router-dom";
 
 export default function Header() {
   // 로그인 상태와 프로필 이미지 관리
   // TODO: Zustand를 통한 로그인 상태 관리
-  // const [isLoggedIn, setIsLoggedIn] = useState(false); // 초기값: 로그아웃 상태
-  // const [profileImage, setProfileImage] = useState(""); // 초기값: 프로필 이미지 없음
-
+  // 초기값 : null 로그아웃 상태
   const { user } = useUserStore();
 
-  console.log(user);
+  const [dropdownVisible, setDropdownVisible] = useState(false);
+
+  const showDropdown = () => {
+    setDropdownVisible(!dropdownVisible);
+  };
 
   return (
     <header className="container mt-[60px] mb-[60px] flex items-center justify-between">
@@ -29,16 +33,14 @@ export default function Header() {
         </Link>
 
         {user ? (
-          <Link to="/profile">
+          <button type="button" className="relative" onClick={showDropdown}>
             <img
               className="w-10 h-10 rounded-full border-2 border-gray1 box-content"
-              src={
-                `https://11.fesp.shop/${user?.profileImage}` ||
-                "/asstes/images/profile-default.png"
-              } // 프로필 이미지가 없으면 기본 이미지 노출
+              src={`https://11.fesp.shop/${user?.profileImage}`} // 프로필 이미지가 없으면 기본 이미지 노출
               alt="User Profile"
             />
-          </Link>
+            {dropdownVisible && <ProfileDropdown />}
+          </button>
         ) : (
           <Link to="/user/login" className="font-bold">
             로그인/회원가입

--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -1,14 +1,15 @@
-import { useState } from "react";
+import useUserStore from "@zustand/userStore";
 import { Link } from "react-router-dom";
 
 export default function Header() {
   // 로그인 상태와 프로필 이미지 관리
   // TODO: Zustand를 통한 로그인 상태 관리
-  const [isLoggedIn, setIsLoggedIn] = useState(false); // 초기값: 로그아웃 상태
-  const [profileImage, setProfileImage] = useState(""); // 초기값: 프로필 이미지 없음
+  // const [isLoggedIn, setIsLoggedIn] = useState(false); // 초기값: 로그아웃 상태
+  // const [profileImage, setProfileImage] = useState(""); // 초기값: 프로필 이미지 없음
 
-  console.log("isLoggedIn:", isLoggedIn);
-  console.log("profileImage:", profileImage);
+  const { user } = useUserStore();
+
+  console.log(user);
 
   return (
     <header className="container mt-[60px] mb-[60px] flex items-center justify-between">
@@ -27,11 +28,14 @@ export default function Header() {
           <img src="/assets/icons/cart.svg" alt="Cart Icon" />
         </Link>
 
-        {isLoggedIn ? (
+        {user ? (
           <Link to="/profile">
             <img
-              className="w-10 h-10 rounded-full"
-              src={profileImage || "/asstes/images/profile-default.png"} // 프로필 이미지가 없으면 기본 이미지 노출
+              className="w-10 h-10 rounded-full border-2 border-gray1 box-content"
+              src={
+                `https://11.fesp.shop/${user?.profileImage}` ||
+                "/asstes/images/profile-default.png"
+              } // 프로필 이미지가 없으면 기본 이미지 노출
               alt="User Profile"
             />
           </Link>

--- a/src/pages/user/Login.jsx
+++ b/src/pages/user/Login.jsx
@@ -77,6 +77,7 @@ export default function Login() {
       // 쿠키에 사용자 정보 저장(_id, accessToken, refreshToken)
       setUser({
         _id: user._id,
+        profileImage: user.image,
         accessToken: user.token.accessToken,
         refreshToken: user.token.refreshToken,
       });

--- a/src/zustand/userStore.js
+++ b/src/zustand/userStore.js
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
-import { cookieStorage } from "zustand-cookie-storage";
+// import { cookieStorage } from "zustand-cookie-storage";
 
 const UserStore = set => ({
   // 기본 사용자 상태값 null
@@ -15,7 +15,7 @@ const UserStore = set => ({
 const useUserStore = create(
   persist(UserStore, {
     name: "user",
-    storage: createJSONStorage(() => cookieStorage),
+    storage: createJSONStorage(() => sessionStorage),
   }),
 );
 


### PR DESCRIPTION
## PR 유형

- [X] 새로운 기능 추가
- [X] 버그 수정
- [X] CSS 등 사용자 UI 디자인 변경
- [] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [] 코드 리팩토링
- [X] 주석 추가 및 수정
- [] 문서 수정
- [] 테스트 추가, 테스트 리팩토링
- [] 빌드 부분 혹은 패키지 매니저 수정
- [] 파일 혹은 폴더명 수정
- [] 파일 혹은 폴더 삭제

## PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### PR 상세
1. useStore 전역 상태 관리 persist 시 sessionStorage 에 저장되도록 변경했습니다.

2. 로그인 이후, 헤더 컴포넌트는 사용자의 이미지로 변경됩니다.
<img width="1046" alt="image" src="https://github.com/user-attachments/assets/57d40db7-451d-442b-a250-33c936943c6b" />

3. 로그인 이후, 프로필 아이콘 클릭 시 마이 프로필 드롭다운이 표시됩니다.
<img width="264" alt="image" src="https://github.com/user-attachments/assets/72be05e2-39dc-4bfd-a81c-5242cfff6ac2" />

4. 상품등록을 선택하면 상품 등록 페이지로 이동합니다.

5. 로그아웃을 선택하면 얼럿창과 함께 로그아웃 처리됩니다.
## 이슈

<!-- 이슈 키워드와 함께 #을 입력한 후 이슈 번호를 선택해주세요. -->
<!-- 예시 : resolves #1 -->

resolves #45
