### PR TITLE
🐞bugfix: 비회원 상태에서 찜하기 버튼 클릭시 불필요한 메시지 삭제 해결(Issue #88 해결)

### DIFF
--- a/src/components/detail/ProductsDetailInfomation.jsx
+++ b/src/components/detail/ProductsDetailInfomation.jsx
@@ -69,12 +69,6 @@ export default function ProductsDetailInfomation({
         alert("찜한 목록에 추가되었습니다.");
       } catch (err) {
         console.error(err);
-        if (err.response) {
-          // 서버에서 반환한 에러 메시지 확인
-          alert(`찜 추가에 실패했습니다: ${err.response.data.message}`);
-        } else {
-          alert("찜 추가에 실패했습니다. 나중에 다시 시도해 주세요.");
-        }
       }
     } else {
       // 찜 삭제


### PR DESCRIPTION
## PR 유형

- [] 새로운 기능 추가
- [x] 버그 수정
- [] CSS 등 사용자 UI 디자인 변경
- [] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [] 코드 리팩토링
- [] 주석 추가 및 수정
- [] 문서 수정
- [] 테스트 추가, 테스트 리팩토링
- [] 빌드 부분 혹은 패키지 매니저 수정
- [] 파일 혹은 폴더명 수정
- [] 파일 혹은 폴더 삭제

## PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### PR 상세
1. 비회원 상태로 상품 상세 페이지에서 찜하기 버튼을 클릭하시면 기존에 불필요한 alert메시지가 출력되지 않습니다.

## 이슈

<!-- 이슈 키워드와 함께 #을 입력한 후 이슈 번호를 선택해주세요. -->
<!-- 예시 : resolves #1 -->

resolves #88
