### PR TITLE
:sparkles:feat: 상품 구매 내역 페이지 마크업 및 기능 구현 완료(Issue #145 해결)

### DIFF
--- a/src/components/common/ProfileDropdown.jsx
+++ b/src/components/common/ProfileDropdown.jsx
@@ -31,6 +31,15 @@ export default function ProfileDropdown() {
         내 정보
       </li>
       <hr className="border border-gray2" />
+      <li
+        className="p-[14px]"
+        onClick={() => {
+          navigate("/myPurchase");
+        }}
+      >
+        구매 내역
+      </li>
+      <hr className="border border-gray2" />
       <li className="p-[14px]" onClick={logout}>
         로그아웃
       </li>

--- a/src/components/myPurchase/MyPurchaseCard.jsx
+++ b/src/components/myPurchase/MyPurchaseCard.jsx
@@ -4,16 +4,23 @@ import PropTypes from "prop-types";
 MyPurchaseCard.propTypes = {
   data: PropTypes.shape({
     products: PropTypes.array,
+    createdAt: PropTypes.string,
   }),
 };
 
 export default function MyPurchaseCard({ data }) {
+  const purchaseDate = new Date(data?.createdAt)
+    .toLocaleDateString()
+    .split("/");
+  const purchaseDateString = `${purchaseDate[2]}년 ${purchaseDate[0]}월 ${purchaseDate[1]}일`;
+  console.log(purchaseDate);
   const multiPurchase = data?.products.map(item => (
     <PurchaseContent key={item._id} data={item} />
   ));
 
   return (
     <li className="p-10 border border-gray2 rounded-lg box-border items-start flex flex-col gap-y-10">
+      <p className="text-lg font-bold">{purchaseDateString}</p>
       {data?.products.length > 1 && (
         <p>
           <strong>{data?.products?.[0].name}</strong> 외{" "}

--- a/src/components/myPurchase/MyPurchaseCard.jsx
+++ b/src/components/myPurchase/MyPurchaseCard.jsx
@@ -10,7 +10,7 @@ MyPurchaseCard.propTypes = {
 
 export default function MyPurchaseCard({ data }) {
   const purchaseDate = new Date(data.createdAt).toLocaleDateString();
-  console.log(purchaseDate);
+
   const multiPurchase = data?.products.map(item => (
     <PurchaseContent key={item._id} data={item} />
   ));

--- a/src/components/myPurchase/MyPurchaseCard.jsx
+++ b/src/components/myPurchase/MyPurchaseCard.jsx
@@ -14,13 +14,17 @@ export default function MyPurchaseCard({ data }) {
 
   return (
     <li className="p-10 border border-gray2 rounded-lg box-border items-start flex flex-col gap-y-10">
+      {data?.products.length > 1 && (
+        <p>
+          <strong>{data?.products?.[0].name}</strong> 외{" "}
+          <strong>{data?.products.length - 1}</strong>건
+        </p>
+      )}
+
       {data?.products.length > 1 ? (
         multiPurchase
       ) : (
-        <PurchaseContent
-          key={data?.products?.[0]._id}
-          data={data?.products[0]}
-        />
+        <PurchaseContent key={data?.products[0]._id} data={data?.products[0]} />
       )}
     </li>
   );

--- a/src/components/myPurchase/MyPurchaseCard.jsx
+++ b/src/components/myPurchase/MyPurchaseCard.jsx
@@ -22,8 +22,10 @@ export default function MyPurchaseCard({ data }) {
       )}
 
       {data?.products.length > 1 ? (
+        // 한 건의 결제 내역에 여러 상품이 포함된 경우(예: 장바구니의 상품 일괄 구매)
         multiPurchase
       ) : (
+        // 한 건의 결제 내역에 하나의 상품이 포함된 경우(예: 상품 상세 페이지에서 바로구매)
         <PurchaseContent key={data?.products[0]._id} data={data?.products[0]} />
       )}
     </li>

--- a/src/components/myPurchase/MyPurchaseCard.jsx
+++ b/src/components/myPurchase/MyPurchaseCard.jsx
@@ -1,5 +1,5 @@
+import PurchaseContent from "@components/myPurchase/PurchaseContent";
 import PropTypes from "prop-types";
-import { Link } from "react-router-dom";
 
 MyPurchaseCard.propTypes = {
   data: PropTypes.shape({
@@ -8,31 +8,20 @@ MyPurchaseCard.propTypes = {
 };
 
 export default function MyPurchaseCard({ data }) {
+  const multiPurchase = data?.products.map(item => (
+    <PurchaseContent key={item._id} data={item} />
+  ));
+
   return (
-    <li className="p-10 flex justify-between gap-x-[60px] border border-gray2 rounded-lg box-border items-center">
-      <Link to={`/products/${data?.products?.[0]._id}`}>
-        <div className="flex gap-x-[60px]">
-          <img
-            src={`https://11.fesp.shop/${data?.products?.[0].image?.path}`}
-            className="size-[150px]"
-            alt="상품 대표 이미지"
-          />
-          <div className="grid grid-flow-row gap-y-[14px] items-center">
-            <h2 className="text-[32px] font-bold">
-              {data?.products?.[0]?.name}
-            </h2>
-            {data?.products.length >= 2 && (
-              <p className="font-bold">{`외 ${data?.products.length} 건`}</p>
-            )}
-            <p className="text-[18px]">
-              <span className="text-[24px] font-bold mr-2">
-                {(data?.products[0].price).toLocaleString()}
-              </span>
-              원
-            </p>
-          </div>
-        </div>
-      </Link>
+    <li className="p-10 border border-gray2 rounded-lg box-border items-start flex flex-col gap-y-10">
+      {data?.products.length > 1 ? (
+        multiPurchase
+      ) : (
+        <PurchaseContent
+          key={data?.products?.[0]._id}
+          data={data?.products[0]}
+        />
+      )}
     </li>
   );
 }

--- a/src/components/myPurchase/MyPurchaseCard.jsx
+++ b/src/components/myPurchase/MyPurchaseCard.jsx
@@ -9,10 +9,7 @@ MyPurchaseCard.propTypes = {
 };
 
 export default function MyPurchaseCard({ data }) {
-  const purchaseDate = new Date(data?.createdAt)
-    .toLocaleDateString()
-    .split("/");
-  const purchaseDateString = `${purchaseDate[2]}년 ${purchaseDate[0]}월 ${purchaseDate[1]}일`;
+  const purchaseDate = new Date(data.createdAt).toLocaleDateString();
   console.log(purchaseDate);
   const multiPurchase = data?.products.map(item => (
     <PurchaseContent key={item._id} data={item} />
@@ -20,7 +17,7 @@ export default function MyPurchaseCard({ data }) {
 
   return (
     <li className="p-10 border border-gray2 rounded-lg box-border items-start flex flex-col gap-y-10">
-      <p className="text-lg font-bold">{purchaseDateString}</p>
+      <p className="text-lg font-bold">{purchaseDate}</p>
       {data?.products.length > 1 && (
         <p>
           <strong>{data?.products?.[0].name}</strong> 외{" "}

--- a/src/components/myPurchase/MyPurchaseCard.jsx
+++ b/src/components/myPurchase/MyPurchaseCard.jsx
@@ -1,0 +1,38 @@
+import PropTypes from "prop-types";
+import { Link } from "react-router-dom";
+
+MyPurchaseCard.propTypes = {
+  data: PropTypes.shape({
+    products: PropTypes.array,
+  }),
+};
+
+export default function MyPurchaseCard({ data }) {
+  return (
+    <li className="p-10 flex justify-between gap-x-[60px] border border-gray2 rounded-lg box-border items-center">
+      <Link to={`/products/${data?.products?.[0]._id}`}>
+        <div className="flex gap-x-[60px]">
+          <img
+            src={`https://11.fesp.shop/${data?.products?.[0].image?.path}`}
+            className="size-[150px]"
+            alt="상품 대표 이미지"
+          />
+          <div className="grid grid-flow-row gap-y-[14px] items-center">
+            <h2 className="text-[32px] font-bold">
+              {data?.products?.[0]?.name}
+            </h2>
+            {data?.products.length >= 2 && (
+              <p className="font-bold">{`외 ${data?.products.length} 건`}</p>
+            )}
+            <p className="text-[18px]">
+              <span className="text-[24px] font-bold mr-2">
+                {(data?.products[0].price).toLocaleString()}
+              </span>
+              원
+            </p>
+          </div>
+        </div>
+      </Link>
+    </li>
+  );
+}

--- a/src/components/myPurchase/PurchaseContent.jsx
+++ b/src/components/myPurchase/PurchaseContent.jsx
@@ -6,6 +6,9 @@ PurchaseContent.propTypes = {
     _id: PropTypes.number,
     name: PropTypes.string,
     price: PropTypes.number,
+    image: PropTypes.shape({
+      path: PropTypes.string,
+    }),
   }),
 };
 
@@ -19,7 +22,9 @@ export default function PurchaseContent({ data }) {
           alt="상품 대표 이미지"
         />
         <div className="grid grid-flow-row gap-y-[14px] items-center">
-          <h2 className="text-[32px] font-bold">{data?.name}</h2>
+          <h2 className="text-[32px] font-bold leading-normal break-words">
+            {data?.name}
+          </h2>
           <p className="text-[18px]">
             <span className="text-[24px] font-bold mr-2">
               {data?.price.toLocaleString()}

--- a/src/components/myPurchase/PurchaseContent.jsx
+++ b/src/components/myPurchase/PurchaseContent.jsx
@@ -1,0 +1,33 @@
+import PropTypes from "prop-types";
+import { Link } from "react-router-dom";
+
+PurchaseContent.propTypes = {
+  data: PropTypes.shape({
+    _id: PropTypes.number,
+    name: PropTypes.string,
+    price: PropTypes.number,
+  }),
+};
+
+export default function PurchaseContent({ data }) {
+  return (
+    <Link to={`/products/${data?._id}`}>
+      <div className="flex gap-x-[60px]">
+        <img
+          src={`https://11.fesp.shop${data?.image?.path || "files/final06/default-profile.png"}`}
+          className="size-[150px]"
+          alt="상품 대표 이미지"
+        />
+        <div className="grid grid-flow-row gap-y-[14px] items-center">
+          <h2 className="text-[32px] font-bold">{data?.name}</h2>
+          <p className="text-[18px]">
+            <span className="text-[24px] font-bold mr-2">
+              {data?.price.toLocaleString()}
+            </span>
+            원
+          </p>
+        </div>
+      </div>
+    </Link>
+  );
+}

--- a/src/components/myPurchase/PurchaseContent.jsx
+++ b/src/components/myPurchase/PurchaseContent.jsx
@@ -15,7 +15,7 @@ PurchaseContent.propTypes = {
 export default function PurchaseContent({ data }) {
   return (
     <Link to={`/products/${data?._id}`}>
-      <div className="flex gap-x-[60px]">
+      <div className="flex gap-x-[60px] ">
         <img
           src={`https://11.fesp.shop${data?.image?.path || "files/final06/default-profile.png"}`}
           className="size-[150px]"

--- a/src/pages/MyPurchase.jsx
+++ b/src/pages/MyPurchase.jsx
@@ -1,3 +1,4 @@
+import EmptyState from "@components/common/EmptyState";
 import MyPurchaseCard from "@components/myPurchase/myPurchaseCard";
 import useAxiosInstance from "@hooks/useAxiosInstance";
 import { useEffect, useState } from "react";
@@ -43,10 +44,13 @@ export default function MyPurchase() {
           <h1 className="page-title">구매 내역</h1>
           <p>총 {myPurchase?.length}건의 구매 내역이 있습니다</p>
         </section>
-
-        <ul className="grid grid-flow-row gap-y-[50px] pb-[50px]">
-          {myPurchaseList}
-        </ul>
+        {myPurchase?.length === 0 ? (
+          <EmptyState message="구매 내역이 없어요 😭" />
+        ) : (
+          <ul className="grid grid-flow-row gap-y-[50px] pb-[50px]">
+            {myPurchaseList}
+          </ul>
+        )}
       </div>
     </>
   );

--- a/src/pages/MyPurchase.jsx
+++ b/src/pages/MyPurchase.jsx
@@ -1,7 +1,29 @@
+import useAxiosInstance from "@hooks/useAxiosInstance";
+import { useEffect, useState } from "react";
 import { Helmet } from "react-helmet-async";
 import { Link } from "react-router-dom";
 
 export default function MyPurchase() {
+  const axios = useAxiosInstance();
+
+  // 구매 내역 상태
+  const [myPurchase, setMyPurchase] = useState();
+
+  // 구매 내역 조회
+  const fetchMyPurchase = async () => {
+    try {
+      const res = await axios.get("/orders");
+      console.log(res.data.item);
+      setMyPurchase(res.data.item);
+    } catch (err) {
+      console.error(err.response.data);
+    }
+  };
+
+  useEffect(() => {
+    fetchMyPurchase();
+  }, []);
+
   return (
     <>
       <Helmet>

--- a/src/pages/MyPurchase.jsx
+++ b/src/pages/MyPurchase.jsx
@@ -1,0 +1,54 @@
+import { Helmet } from "react-helmet-async";
+import { Link } from "react-router-dom";
+
+export default function MyPurchase() {
+  return (
+    <>
+      <Helmet>
+        <title>구매 내역 - ILAND</title>
+
+        <meta property="og:title" content="구매 내역 - ILAND" />
+        <meta
+          property="og:description"
+          content="ILAND에서 내 취향을 모아보세요."
+        />
+      </Helmet>
+      <div className="container">
+        <section className="mb-[50px]">
+          <h1 className="page-title">구매 내역</h1>
+          <p>총 10개의 찜한 상품이 있습니다</p>
+        </section>
+
+        <ul className="grid grid-flow-row gap-y-[50px] pb-[50px]">
+          <li
+            key=""
+            className="p-10 flex justify-between gap-x-[60px] border border-gray2 rounded-lg box-border items-center"
+          >
+            <div className="flex gap-x-[60px]">
+              <Link to={`/products/1`}>
+                <img
+                  src="https://11.fesp.shop/files/final06/default-profile.png"
+                  className="size-[150px]"
+                  alt="상품 대표 이미지"
+                />
+              </Link>
+              <div className="grid grid-flow-row gap-y-[14px] items-center">
+                <div className="text-[18px] text-gray3 flex gap-x-[10px] items-center">
+                  판매자명
+                  <img
+                    src="/assets/icons/chevron-right.svg"
+                    className="w-[6px] h-3"
+                  />
+                </div>
+                <h2 className="text-[32px] font-bold">상품 명</h2>
+                <p className="text-[18px]">
+                  <span className="text-[24px] font-bold">10,000</span>원
+                </p>
+              </div>
+            </div>
+          </li>
+        </ul>
+      </div>
+    </>
+  );
+}

--- a/src/pages/MyPurchase.jsx
+++ b/src/pages/MyPurchase.jsx
@@ -1,7 +1,7 @@
+import MyPurchaseCard from "@components/myPurchase/myPurchaseCard";
 import useAxiosInstance from "@hooks/useAxiosInstance";
 import { useEffect, useState } from "react";
 import { Helmet } from "react-helmet-async";
-import { Link } from "react-router-dom";
 
 export default function MyPurchase() {
   const axios = useAxiosInstance();
@@ -24,6 +24,10 @@ export default function MyPurchase() {
     fetchMyPurchase();
   }, []);
 
+  const myPurchaseList = myPurchase?.map(item => (
+    <MyPurchaseCard key={item._id} data={item} />
+  ));
+
   return (
     <>
       <Helmet>
@@ -38,37 +42,11 @@ export default function MyPurchase() {
       <div className="container">
         <section className="mb-[50px]">
           <h1 className="page-title">구매 내역</h1>
-          <p>총 10개의 찜한 상품이 있습니다</p>
+          <p>총 {myPurchase?.length}개의 구매 내역이 있습니다</p>
         </section>
 
         <ul className="grid grid-flow-row gap-y-[50px] pb-[50px]">
-          <li
-            key=""
-            className="p-10 flex justify-between gap-x-[60px] border border-gray2 rounded-lg box-border items-center"
-          >
-            <div className="flex gap-x-[60px]">
-              <Link to={`/products/1`}>
-                <img
-                  src="https://11.fesp.shop/files/final06/default-profile.png"
-                  className="size-[150px]"
-                  alt="상품 대표 이미지"
-                />
-              </Link>
-              <div className="grid grid-flow-row gap-y-[14px] items-center">
-                <div className="text-[18px] text-gray3 flex gap-x-[10px] items-center">
-                  판매자명
-                  <img
-                    src="/assets/icons/chevron-right.svg"
-                    className="w-[6px] h-3"
-                  />
-                </div>
-                <h2 className="text-[32px] font-bold">상품 명</h2>
-                <p className="text-[18px]">
-                  <span className="text-[24px] font-bold">10,000</span>원
-                </p>
-              </div>
-            </div>
-          </li>
+          {myPurchaseList}
         </ul>
       </div>
     </>

--- a/src/pages/MyPurchase.jsx
+++ b/src/pages/MyPurchase.jsx
@@ -13,7 +13,6 @@ export default function MyPurchase() {
   const fetchMyPurchase = async () => {
     try {
       const res = await axios.get("/orders");
-      console.log(res.data.item);
       setMyPurchase(res.data.item);
     } catch (err) {
       console.error(err.response.data);
@@ -42,7 +41,7 @@ export default function MyPurchase() {
       <div className="container">
         <section className="mb-[50px]">
           <h1 className="page-title">구매 내역</h1>
-          <p>총 {myPurchase?.length}개의 구매 내역이 있습니다</p>
+          <p>총 {myPurchase?.length}건의 구매 내역이 있습니다</p>
         </section>
 
         <ul className="grid grid-flow-row gap-y-[50px] pb-[50px]">

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -15,6 +15,7 @@ import Layout from "@components/layout";
 import PrivateRoute from "@components/common/PrivateRoute";
 import LoginKakao from "@pages/users/LoginKakao";
 import MyInfo from "@pages/users/MyInfo";
+import MyPurchase from "@pages/MyPurchase";
 
 const router = createBrowserRouter(
   [
@@ -39,6 +40,7 @@ const router = createBrowserRouter(
             { path: "carts", element: <Carts /> },
             { path: "users/myInfo", element: <MyInfo /> },
             { path: "payment", element: <Payment /> },
+            { path: "myPurchase", element: <MyPurchase /> },
           ],
         },
         { path: "products", element: <Products /> },


### PR DESCRIPTION
## PR 유형

- [X] 새로운 기능 추가
- [] 버그 수정
- [] CSS 등 사용자 UI 디자인 변경
- [] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [] 코드 리팩토링
- [X] 주석 추가 및 수정
- [] 문서 수정
- [] 테스트 추가, 테스트 리팩토링
- [] 빌드 부분 혹은 패키지 매니저 수정
- [X] 파일 혹은 폴더명 수정
- [] 파일 혹은 폴더 삭제

## PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### PR 상세
1. 로그인 이후 프로필 이미지 드롭다운에서 "구매 내역"을 클릭 시 "구매 내역" 페이지로 이동합니다.

2. 사용자의 구매 내역이 없는 경우, EmptyState 화면이 출력됩니다.

3. 하나의 구매 내역에 하나의 상품만 포함되는 경우 아래 이미지와 같이 표시됩니다.
<img width="1145" alt="image" src="https://github.com/user-attachments/assets/f53f069a-6c75-4196-a0fa-1aa2088dfd3b" />

4. 하나의 구매 내역에 다수의 상품만 포함되는 경우 아래 이미지와 같이 표시됩니다.
<img width="1091" alt="image" src="https://github.com/user-attachments/assets/676f01f6-24dc-42c0-b941-1606ea5ec76e" />

## 이슈

<!-- 이슈 키워드와 함께 #을 입력한 후 이슈 번호를 선택해주세요. -->
<!-- 예시 : resolves #1 -->

resolves #145 
